### PR TITLE
Add dbplyr dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
     
 r_binary_packages:
  - dplyr
+ - dbplyr
  
  # Install the bleeding edge version of a package from github (eg to pick
 # up a not-yet-released bugfix)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ License: CC0
 LazyData: true
 Imports:
     dplyr,
+    dbplyr,
     DBI,
     downloader,
     lubridate,


### PR DESCRIPTION
The database portion of `dplyr` has been split into the `dbplyr` package. This change should make the travis-ci build succeed.